### PR TITLE
chore: Add Sentry error capture for API request and JSON decoding failures

### DIFF
--- a/ios-app/OnTime/api/ApiClient.swift
+++ b/ios-app/OnTime/api/ApiClient.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Sentry
 
 actor ApiClient {
     static let shared = ApiClient()
@@ -22,14 +23,21 @@ actor ApiClient {
             return data
         }
         
-        let (data, _) = try await session.data(from: URL(string: endpoint)!)
-        
+        let data: Data
+        do {
+            (data, _) = try await session.data(from: URL(string: endpoint)!)
+        } catch {
+            SentrySDK.capture(error: error)
+            throw error
+        }
+
         var decoded: DeparturesResponse? = nil
         do {
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601
             decoded = try decoder.decode(DeparturesResponse.self, from: data)
         } catch {
+            SentrySDK.capture(error: error)
             print(error)
         }
         
@@ -97,6 +105,7 @@ actor ApiClient {
                         if attempt < maxRetries - 1 {
                             continue
                         }
+                        SentrySDK.capture(error: error)
                         throw error
                     }
                 }
@@ -135,14 +144,22 @@ actor ApiClient {
         }
         
         
-        let (data, _) = try await session.data(from: URL(string: endpoint)!)
+        let data: Data
+        do {
+            (data, _) = try await session.data(from: URL(string: endpoint)!)
+        } catch {
+            SentrySDK.capture(error: error)
+            throw error
+        }
+
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        
+
         var decoded: TripResponse? = nil
         do {
             decoded = try decoder.decode(TripResponse.self, from: data)
         } catch {
+            SentrySDK.capture(error: error)
             print(error)
         }
         

--- a/ios-app/OnTime/api/utils/CombineApiHelper.swift
+++ b/ios-app/OnTime/api/utils/CombineApiHelper.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import Sentry
 import SwiftUI
 
 class CombineApiHelper {
@@ -35,6 +36,7 @@ class CombineApiHelper {
                 case .finished:
                     print("Request completed successfully")
                 case .failure(let error):
+                    SentrySDK.capture(error: error)
                     print("Error fetching from \(urlString): \(error.localizedDescription)")
                 }
             }, receiveValue: { request in responseHandler(request) })


### PR DESCRIPTION
## Summary
- Wraps `URLSession.data()` calls in `ApiClient` in do-catch blocks so network errors are reported to Sentry before being rethrown to the caller
- Adds `SentrySDK.capture(error:)` to the existing JSON decode error catch blocks in `fetchDepartures` and `fetchTrip`, which were previously swallowing errors silently (only printing to console)
- In `fetchMultipleDepartures`, captures the error only after all retries are exhausted — transient failures that recover on retry are intentionally not reported to avoid noise
- `CombineApiHelper` now captures errors in the Combine sink `.failure` case, covering both network and decode failures in the Combine-based pipeline
## Reviewer notes
Sentry is connected to a self-hosted server (not sentry.io). No DSN or credentials are hardcoded here — those were set up via the Sentry Wizard and live in the SDK init in `OnTimeApp.swift`.